### PR TITLE
Calendar walkthrough: Optional attendee functionality

### DIFF
--- a/walkthroughs/week-2-web-development/portfolio-walkthrough.md
+++ b/walkthroughs/week-2-web-development/portfolio-walkthrough.md
@@ -53,17 +53,29 @@ You'll learn more about these files in the following steps.
 
 ## Java 8
 
-Before you continue, set your default Java version to Java 8 by running this
-command:
+Before you continue, set your default Java version to Java 8.
+
+To do that, first open your `.bashrc` file by running this command:
 
 ```bash
+edit ~/.bashrc
+```
+
+This file sets up your console configuration. Copy this line into the end of
+that file:
+
+```
 sudo update-java-alternatives -s java-1.8.0-openjdk-amd64 && export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
 ```
 
+Save and close the `.bashrc` file, and then execute it using this command:
+
+```bash
+source ~/.bashrc
+```
+
 You can ignore any error messages about not being able to find alternatives for
-various plugins. Your Java version setting will persist unless you restart your
-Cloud shell instance. To permanently switch to Java 8, add the command above to
-your `.bashrc` file.
+various plugins.
 
 ### Why Java 8?
 
@@ -71,13 +83,14 @@ Google Cloud recently announced support for Java 11, but Java 11 is not
 backwards compatible with every library in these walkthroughs. To make sure
 everything will work as expected, please use Java 8.
 
-To make sure you're using the correct version of Java, run this command:
+To make sure you're using the correct version of Java, run these commands:
 
 ```bash
+echo $JAVA_HOME
 java -version
 ```
 
-If this command prints a version like `1.8.0_xxx`, then you're good to go!
+If these commands print a version like `1.8.0_xxx`, then you're good to go!
 
 ## Run a Development Server
 

--- a/walkthroughs/week-2-web-development/portfolio-walkthrough.md
+++ b/walkthroughs/week-2-web-development/portfolio-walkthrough.md
@@ -164,10 +164,12 @@ After your server is running again, click the
 select `Preview on port 8080` to see your changes. Get in the habit of rerunning
 your dev server to test your changes often!
 
-**Note:** If you don't see your changes after you refresh, your browser might be
-caching an old version. Follow the instructions
-[here](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache) to execute a
-cache-clearing refresh.
+**Warning:** If you don't see your changes after you refresh, your browser might
+be caching an old version. Perform a
+[cache-clearing refresh](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache)
+to force your browser to download the new files. In Chrome, open the Chrome Menu
+and click More Tools > Developer Tools. Then click and hold the browser Refresh
+button and select Empty Cache and Hard Reload from the drop-down menu.
 
 ## Example
 

--- a/walkthroughs/week-3-server/step-1-servlets-walkthrough.md
+++ b/walkthroughs/week-3-server/step-1-servlets-walkthrough.md
@@ -131,7 +131,7 @@ Second, using a framework involves a lot of setup and configuration. Code is
 hard enough to debug, even without fighting with framework config files!
 
 Third, most of the Google Cloud tutorials use servlets. So anything you find in
-a Google Cloud tutorial should "just work" with the code you during SPS.
+a Google Cloud tutorial should "just work" with the code you write during STEP.
 
 All of that said, if using a framework is interesting to you, consider exploring
 that during the open project!

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.googl.sps.servlets;
+package com.google.sps.servlets;
 
 import com.google.appengine.api.blobstore.BlobInfo;
 import com.google.appengine.api.blobstore.BlobInfoFactory;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -25,9 +25,6 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     List<TimeRange> availableTimes = new ArrayList<>();
     
-    // The basic functionality of optional attendees is that if one or more time slots exists so 
-    // that both mandatory and optional attendees can attend, return those time slots.  
-    // Otherwise, return the time slots that fit just the mandatory attendees.
     if (!request.getOptionalAttendees().isEmpty()) {
       handleQuery(events, request, availableTimes, true);
       if (availableTimes.isEmpty()) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -25,13 +25,16 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     List<TimeRange> availableTimes = new ArrayList<>();
     
+    // First we try to find a meeting time that works for all attendees, including optional.
     if (!request.getOptionalAttendees().isEmpty()) {
-      handleQuery(events, request, availableTimes, true);
+      handleQuery(events, request, availableTimes, /* includeOptional= */ true);
+      
+      // If nothing is available, try again, excluding optional attendees.
       if (availableTimes.isEmpty()) {
-        handleQuery(events, request, availableTimes, false);
+        handleQuery(events, request, availableTimes, /* includeOptional= */ false);
       }
     } else {
-      handleQuery(events, request, availableTimes, false);
+      handleQuery(events, request, availableTimes, /* includeOptional= */ false);
     }
 
     return availableTimes;
@@ -88,21 +91,21 @@ public final class FindMeetingQuery {
     if (availableTime.contains(eventRange)) {
       start = availableTime.start();
       end = eventRange.start();
-      addTimeRangeToList(newAvailableRanges, start, end, false);
+      addTimeRangeToList(newAvailableRanges, start, end, /* inclusive= */ false);
 
       start = eventRange.end();
       end = availableTime.end();
-      addTimeRangeToList(newAvailableRanges, start, end, false);
+      addTimeRangeToList(newAvailableRanges, start, end, /* inclusive= */ false);
     } else if (eventRange.contains(availableTime)) {
       // If an event spans the whole available time, no new range will be available.
     } else if (eventRange.start() < availableTime.start()) {
       start = eventRange.end();
       end = availableTime.end();
-      addTimeRangeToList(newAvailableRanges, start, end, false);
+      addTimeRangeToList(newAvailableRanges, start, end, /* inclusive= */ false);
     } else if (eventRange.end() > availableTime.end()) {
       start = availableTime.start();
       end = eventRange.start();
-      addTimeRangeToList(newAvailableRanges, start, end, false);
+      addTimeRangeToList(newAvailableRanges, start, end, /* inclusive= */ false);
     }
   }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -21,6 +21,15 @@ import java.util.Collections;
 import java.util.HashSet;
 
 public final class MeetingRequest {
+
+  /////////////////////////////////////////////
+  // WARNING:
+  /////////////////////////////////////////////
+  // Any new fields added to this class
+  // must be reflected in the class of the
+  // same name in script.js
+  /////////////////////////////////////////////
+
   // All the people that should be attending this new meeting. Use a set to avoid duplicates.
   private final Collection<String> attendees = new HashSet<>();
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -38,7 +38,9 @@ public final class MeetingRequest {
   public MeetingRequest(Collection<String> attendees, Collection<String> optionals, long duration) {
     this.duration = duration;
     this.attendees.addAll(attendees);
-    this.optional_attendees.addAll(optionals);
+    for (String optional_attendee : optionals) {
+      addOptionalAttendee(optional_attendee);
+    }
   }
 
   /**

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -35,6 +35,12 @@ public final class MeetingRequest {
     this.attendees.addAll(attendees);
   }
 
+  public MeetingRequest(Collection<String> attendees, Collection<String> optionals, long duration) {
+    this.duration = duration;
+    this.attendees.addAll(attendees);
+    this.optional_attendees.addAll(optionals);
+  }
+
   /**
    * Returns a read-only copy of the people who are required to attend this meeting.
    */

--- a/walkthroughs/week-5-tdd/project/src/main/webapp/index.html
+++ b/walkthroughs/week-5-tdd/project/src/main/webapp/index.html
@@ -20,6 +20,10 @@
       <p>Who needs to attend the meeting (comma-separated list)?</p>
       <input id="attendees" type="text" placeholder="Amelia, Ava, Emma" />
 
+      <h2>Optional Attendees</h2>
+      <p>Who can attend the meeting optionally (comma-separated list)?</p>
+      <input id="optional-attendees" type="text" placeholder="Amelia, Ava, Emma" />
+
       <h2>Duration</h2>
       <p>How long is your meeting (minutes)?</p>
       <input id="duration" type="number" min="0" />

--- a/walkthroughs/week-5-tdd/project/src/main/webapp/script.js
+++ b/walkthroughs/week-5-tdd/project/src/main/webapp/script.js
@@ -24,9 +24,14 @@ function sendMeetingRequest() {
   // split it into an array of names
   const attendees = attendeesNamesString.split(/\s*,\s*/);
 
+// comma-separated list of names
+  const optionalAttendeesNamesString = document.getElementById('optional-attendees').value;
+  // split it into an array of names
+  const optionalAttendees = optionalAttendeesNamesString.split(/\s*,\s*/);
+
   // Create the request to send to the server using the data we collected from
   // the web form.
-  const meetingRequest = new MeetingRequest(duration, attendees);
+  const meetingRequest = new MeetingRequest(duration, attendees, optionalAttendees);
 
   queryServer(meetingRequest).then((timeRanges) => {
     updateResultsOnPage(timeRanges);
@@ -87,9 +92,10 @@ function timeToString(totalMinutes) {
  * Request for possible meeting times.
  */
 class MeetingRequest {
-  constructor(duration, attendees) {
+  constructor(duration, attendees, optional_attendees) {
     this.duration = duration;
     this.attendees = attendees;
+    this.optional_attendees = optional_attendees;
   }
 }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -394,17 +394,17 @@ public final class FindMeetingQueryTest {
   @Test
   public void noTimesWithOptionalOnly() {
     // Have each optional attendee have different events with no gap.
-    // No time should be available. (WHY???)
+    // The whole day should be available.
     //
     // Events  :       
     // Optional: |------A------||------B------|
     // Day     : |----------------------------|
-    // Options : 
+    // Options : |----------------------------|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+        new Event("Event 1", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TIME_0830AM),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0830AM, TimeRange.END_OF_DAY),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
@@ -412,7 +412,7 @@ public final class FindMeetingQueryTest {
             DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList();
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,8 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
+
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +45,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 30;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -264,6 +267,149 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeNotConsidered() {
+    // Have each person have different events. We should see 3 options because each person has
+    // split the restricted times. Optional attendee C has an all day event.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional: |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C), 
+            DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeIsConsidered() {
+    // Have each person have different events. Optional attendee C has an event
+    // between the two mandatory ones. We should see two options remaining.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional:             |--C--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--2--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), 
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C),
+            DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void notEnoughRoomForOptional() {
+    // Have one person, and one optional attendee, but make it so that there is only
+    // enough room at one point in the day to have the meeting without the optional attendee.
+    //
+    // Events  : |--A--|      |----A----|
+    // Optional:       |-B-| 
+    // Day     : |----------------------|
+    // Options :       |------|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES), 
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), Arrays.asList(PERSON_B),
+        DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendees() {
+    // Have each optional attendee have different events.
+    // We should see three meeting options remaining.
+    //
+    // Events  :       
+    // Optional:       |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), Arrays.asList(PERSON_A, PERSON_B),
+            DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noTimesWithOptionalOnly() {
+    // Have each optional attendee have different events with no gap.
+    // No time should be available. (WHY???)
+    //
+    // Events  :       
+    // Optional: |------A------||------B------|
+    // Day     : |----------------------------|
+    // Options : 
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), Arrays.asList(PERSON_A, PERSON_B),
+            DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();


### PR DESCRIPTION
Continue week 5's calendar/tdd walkthrough:
- Include 5 more tests that include optional attendees
- Support optional attendee functionality
- Code passes all test cases*

From the walkthrough: 
> The basic functionality of optional attendees is that if one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots. Otherwise, return the time slots that fit just the mandatory attendees.

*Note, test 5 in the walkthrough describes this scenario:
> No mandatory attendees, just two optional attendees with no gaps in their schedules. `query` should return that no time is available.

However, I think the intended functionality is actually ambiguous. If two optional attendees are busy the whole day, then no time would be available. This means that we should just return the time slots that fit the mandatory attendees. In the optionsForNoAttendees() test, a meeting with no attendees returned a possible TimeFrame of the whole day. I think that the scenario in test 5 should also return a possible TimeFrame of the whole day. For now, I went ahead and coded the test according to what is consistent with the previous code. But this can be easily changed later on to reflect what the walkthrough says.
